### PR TITLE
Add sphere collision tests

### DIFF
--- a/src/math/sphere.cpp
+++ b/src/math/sphere.cpp
@@ -7,6 +7,13 @@ using simphys::math::Ray;
 
 bool Sphere::Colision(const Geometry &other) const noexcept
 {
+    const auto* other_sphere = dynamic_cast<const Sphere*>(&other);
+    if(other_sphere)
+    {
+        const auto centre_dist = (this->position_ - other_sphere->position_).mag();
+        return centre_dist <= (this->radius_ + other_sphere->radius_);
+    }
+
     return false;
 }
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 message("INCLUDE TESTS")
 
 file(GLOB_RECURSE TEST_SRC ./*.cpp )
+# Explicitly include new sphere collision tests
+list(APPEND TEST_SRC math/TestSphereCollision.cpp)
 
 message("======= TEST ======")
 message("Source: ${SRC}")

--- a/unit_tests/math/TestSphereCollision.cpp
+++ b/unit_tests/math/TestSphereCollision.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include "math/sphere.hpp"
+
+using simphys::math::Sphere;
+using simphys::math::Point;
+using simphys::math::Geometry;
+
+TEST(SphereCollisionTests, OverlappingSpheres)
+{
+    Sphere s1(Point(0, 0, 0), 1.0);
+    Sphere s2(Point(1.0, 0, 0), 1.0);
+
+    EXPECT_TRUE(s1.Colision(s2));
+    EXPECT_TRUE(s2.Colision(s1));
+}
+
+TEST(SphereCollisionTests, TouchingSpheres)
+{
+    Sphere s1(Point(0, 0, 0), 1.0);
+    Sphere s2(Point(2.0, 0, 0), 1.0);
+
+    EXPECT_TRUE(s1.Colision(s2));
+    EXPECT_TRUE(s2.Colision(s1));
+}
+
+TEST(SphereCollisionTests, SeparateSpheres)
+{
+    Sphere s1(Point(0, 0, 0), 1.0);
+    Sphere s2(Point(3.0, 0, 0), 1.0);
+
+    EXPECT_FALSE(s1.Colision(s2));
+    EXPECT_FALSE(s2.Colision(s1));
+}


### PR DESCRIPTION
## Summary
- implement `Sphere::Colision` to check sphere-sphere distance
- add `TestSphereCollision.cpp` verifying sphere collision logic
- list the new test file in `unit_tests/CMakeLists.txt`

## Testing
- `cmake -S . -B build` *(fails: could not download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_688641e1e8a883278bc17f20170872fa