### PR TITLE
Implement broad-phase collision manager

### DIFF
--- a/inc/math/geometry.hpp
+++ b/inc/math/geometry.hpp
@@ -7,12 +7,15 @@ namespace math {
 class Geometry
 {
 public:
-	Geometry(const Point& position) : position_(position) {}
+        Geometry(const Point& position) : position_(position) {}
 
-	virtual bool Colision(const Geometry& other) const noexcept = 0;
+        virtual bool Colision(const Geometry& other) const noexcept = 0;
     virtual bool RayHit(const Ray& ray) const noexcept = 0;
 
-	virtual ~Geometry() = default;
+        virtual ~Geometry() = default;
+
+    const Point& Position() const noexcept { return position_; }
+
 protected:
     Point position_; //  Idealy, the center of mass
 };

--- a/inc/math/geometry.hpp
+++ b/inc/math/geometry.hpp
@@ -1,3 +1,6 @@
+#ifndef SIMPHYS_INC_MATH_GEOMETRY_HPP
+#define SIMPHYS_INC_MATH_GEOMETRY_HPP
+
 #include "vec3.hpp"
 #include "ray.hpp"
 
@@ -23,3 +26,5 @@ protected:
 
 }
 }
+
+#endif  // SIMPHYS_INC_MATH_GEOMETRY_HPP

--- a/inc/math/line.hpp
+++ b/inc/math/line.hpp
@@ -1,3 +1,7 @@
+#ifndef SIMPHYS_INC_MATH_LINE_HPP
+#define SIMPHYS_INC_MATH_LINE_HPP
+
+
 #include "math/vec3.hpp"
 
 #include <cmath>
@@ -44,3 +48,4 @@ public:
 }
 }
 
+#endif  // SIMPHYS_INC_MATH_LINE_HPP

--- a/inc/math/ray.hpp
+++ b/inc/math/ray.hpp
@@ -1,3 +1,7 @@
+#ifndef PHYSIM_INC_MATH_RAY_HPP
+#define PHYSIM_INC_MATH_RAY_HPP
+
+
 #include "line.hpp"
 
 namespace simphys
@@ -14,3 +18,6 @@ public:
 
 }  // math
 }  // simphys
+
+
+#endif  // PHYSIM_INC_MATH_RAY_HPP

--- a/inc/math/sphere.hpp
+++ b/inc/math/sphere.hpp
@@ -12,6 +12,8 @@ public:
 
     bool Colision(const Geometry &other) const noexcept override;
     bool RayHit(const Ray &ray) const noexcept override;
+
+    double Radius() const noexcept { return radius_; }
 };
 
 

--- a/inc/math/sphere.hpp
+++ b/inc/math/sphere.hpp
@@ -1,3 +1,6 @@
+#ifndef PHYSIM_INC_MATH_SPHERE_HPP
+#define PHYSIM_INC_MATH_SPHERE_HPP
+
 #include "geometry.hpp"
 
 namespace simphys {
@@ -19,3 +22,6 @@ public:
 
 }
 }
+
+
+#endif  // PHYSIM_INC_MATH_SPHERE_HPP

--- a/inc/math/vec3.hpp
+++ b/inc/math/vec3.hpp
@@ -1,5 +1,6 @@
 #ifndef __PHYSIM_MATH_VEC3__
 #define __PHYSIM_MATH_VEC3__
+
 #include <cstdlib>
 #include <cmath>
 #include <functional>

--- a/inc/objects/collision_manager.hpp
+++ b/inc/objects/collision_manager.hpp
@@ -1,0 +1,80 @@
+#ifndef OBJECTS_COLLISION_MANAGER_HPP
+#define OBJECTS_COLLISION_MANAGER_HPP
+
+#include <unordered_map>
+#include <vector>
+#include <utility>
+#include <cmath>
+
+#include "objects/object_base.hpp"
+
+namespace simphys {
+namespace sim {
+
+class CollisionManager
+{
+    struct CellCoord {
+        int x, y, z;
+        bool operator==(const CellCoord& o) const noexcept {
+            return x==o.x && y==o.y && z==o.z;
+        }
+    };
+
+    struct CellHash {
+        std::size_t operator()(const CellCoord& c) const noexcept {
+            std::size_t h1 = std::hash<int>()(c.x);
+            std::size_t h2 = std::hash<int>()(c.y);
+            std::size_t h3 = std::hash<int>()(c.z);
+            return h1 ^ (h2 << 1) ^ (h3 << 2);
+        }
+    };
+
+    double cell_size_;
+    std::vector<ObjectBase*> objects_;
+    std::unordered_map<CellCoord, std::vector<ObjectBase*>, CellHash> grid_;
+
+    CellCoord CellForPoint(const math::Point& p) const noexcept {
+        return CellCoord{static_cast<int>(std::floor(p.x()/cell_size_)),
+                         static_cast<int>(std::floor(p.y()/cell_size_)),
+                         static_cast<int>(std::floor(p.z()/cell_size_))};
+    }
+
+public:
+    explicit CollisionManager(double cell_size) : cell_size_(cell_size) {}
+
+    void AddObject(ObjectBase* obj) { objects_.push_back(obj); }
+    void ClearObjects() { objects_.clear(); }
+
+    std::vector<std::pair<ObjectBase*, ObjectBase*>> DetectCollisions()
+    {
+        grid_.clear();
+        for(auto* obj : objects_)
+        {
+            auto cell = CellForPoint(obj->BoundingSphere().Position());
+            grid_[cell].push_back(obj);
+        }
+
+        std::vector<std::pair<ObjectBase*, ObjectBase*>> collisions;
+        for(auto& [cell, objs] : grid_)
+        {
+            for(std::size_t i=0;i<objs.size();++i)
+                for(std::size_t j=i+1;j<objs.size();++j)
+                {
+                    const auto& a = objs[i]->BoundingSphere();
+                    const auto& b = objs[j]->BoundingSphere();
+                    const auto centre_dist = (a.Position() - b.Position()).mag();
+                    if(centre_dist <= (a.Radius()+b.Radius()))
+                    {
+                        if(objs[i]->ColidesWith(*objs[j]))
+                            collisions.emplace_back(objs[i], objs[j]);
+                    }
+                }
+        }
+        return collisions;
+    }
+};
+
+} // namespace sim
+} // namespace simphys
+
+#endif // OBJECTS_COLLISION_MANAGER_HPP

--- a/inc/objects/object_base.hpp
+++ b/inc/objects/object_base.hpp
@@ -3,14 +3,18 @@
 
 #include "math/geometry.hpp"
 #include "math/ray.hpp"
+#include "math/sphere.hpp"
 
 namespace simphys {
 namespace sim {
 
 class ObjectBase
 {
+public:
+    virtual ~ObjectBase() = default;
     virtual bool ColidesWith(const ObjectBase& other) = 0;
     virtual bool RayHit(const math::Ray& ray) = 0;
+    virtual const math::Sphere& BoundingSphere() const noexcept = 0;
 };
 
 }

--- a/inc/objects/sphere.hpp
+++ b/inc/objects/sphere.hpp
@@ -6,7 +6,14 @@ namespace sim {
 
 class Sphere : public ObjectBase
 {
-	Sphere() = delete;
+    math::Sphere geometry_;
+public:
+    Sphere(const math::Point& centre, double radius) : geometry_(centre, radius) {}
+    Sphere() = delete;
+
+    bool ColidesWith(const ObjectBase& other) override;
+    bool RayHit(const math::Ray& ray) override;
+    const math::Sphere& BoundingSphere() const noexcept override { return geometry_; }
 };
 }
 }

--- a/src/objects/sphere.cpp
+++ b/src/objects/sphere.cpp
@@ -1,0 +1,18 @@
+#include "objects/sphere.hpp"
+
+using simphys::sim::Sphere;
+using simphys::sim::ObjectBase;
+using simphys::math::Ray;
+
+bool Sphere::ColidesWith(const ObjectBase& other)
+{
+    const auto* other_sphere = dynamic_cast<const Sphere*>(&other);
+    if(other_sphere)
+        return geometry_.Colision(other_sphere->geometry_);
+    return false;
+}
+
+bool Sphere::RayHit(const Ray& ray)
+{
+    return geometry_.RayHit(ray);
+}


### PR DESCRIPTION
## Summary
- expose geometry position accessor
- expose sphere radius accessor
- extend object base interface with `BoundingSphere()`
- implement a `Sphere` object with basic collision methods
- add `CollisionManager` for broad-phase detection using a spatial grid

## Testing
- `cmake ..` *(fails: unable to download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_688780f4590c8327980f423df9880cd3